### PR TITLE
Add support for integer literals in binary, octal, and hex

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -21,9 +21,29 @@ pub fn parse(input: &str) -> ParseResult<Expr, EmptyErr> {
 fn parser<'src>() -> impl Parser<'src, &'src str, Expr> {
   use Expr::*;
 
-  let number = text::digits(10)
-    .to_slice()
-    .map(|s: &str| Literal(s.parse::<i64>().unwrap()));
+  let number = {
+    let hex = just("0x")
+      .ignore_then(text::digits(16).to_slice())
+      .map(|s| i64::from_str_radix(s, 16).unwrap());
+
+    let octal = just("0o")
+      .ignore_then(text::digits(8).to_slice())
+      .map(|s| i64::from_str_radix(s, 8).unwrap());
+
+    let binary = just("0b")
+      .ignore_then(text::digits(2).to_slice())
+      .map(|s| i64::from_str_radix(s, 2).unwrap());
+
+    let decimal = text::digits(10)
+      .to_slice()
+      .map(|s: &str| s.parse::<i64>().unwrap());
+
+    hex
+      .or(octal)
+      .or(binary)
+      .or(decimal)
+      .map(Literal)
+  };
 
   let op = |c| just(c);
 
@@ -39,4 +59,51 @@ fn parser<'src>() -> impl Parser<'src, &'src str, Expr> {
     ))
   })
   .then_ignore(end())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+    use crate::eval;
+
+    fn parse_and_eval(input: &str) -> i64 {
+        let (expr, errs) = parse(input).into_output_errors();
+        assert!(errs.is_empty());
+        eval(expr.unwrap())
+    }
+
+    #[test]
+    fn test_parse_binary() {
+        assert_eq!(parse_and_eval("0b1010"), 10);
+        assert_eq!(parse_and_eval("0b1111"), 15);
+    }
+
+    #[test]
+    fn test_parse_octal() {
+        assert_eq!(parse_and_eval("0o12"), 10);
+        assert_eq!(parse_and_eval("0o77"), 63);
+    }
+
+    #[test]
+    fn test_parse_hexadecimal() {
+        assert_eq!(parse_and_eval("0x10"), 16);
+        assert_eq!(parse_and_eval("0xff"), 255);
+        assert_eq!(parse_and_eval("0xCAFE"), 51966);
+    }
+
+    #[test]
+    fn test_parse_expressions() {
+        assert_eq!(parse_and_eval("0b10 + 0o10 + 0x10"), 2 + 8 + 16);
+        assert_eq!(parse_and_eval("0b10 * 0o10 - 0x10"), 2 * 8 - 16);
+    }
+
+    #[test]
+    fn test_invalid_literals() {
+        assert!(parse("0b2").has_errors());
+        assert!(parse("0o8").has_errors());
+        assert!(parse("0xg").has_errors());
+        assert!(parse("0b").has_errors());
+        assert!(parse("0o").has_errors());
+        assert!(parse("0x").has_errors());
+    }
 }


### PR DESCRIPTION
Add support for specifying integer literals in binary (with a 0b prefix), octal (with a 0o prefix), and hexadecimal (with a 0x prefix).

The parser in `src/syntax.rs` has been updated to recognize these new formats. Tests have been added to verify the new functionality and ensure that expressions involving these literals are evaluated correctly.